### PR TITLE
Fix failing migration when using latest Rails version

### DIFF
--- a/db/migrate/002_create_roles.rb
+++ b/db/migrate/002_create_roles.rb
@@ -15,7 +15,9 @@ class CreateRoles < ActiveRecord::Migration
 
   def create_roles
     SimpleRoles::Configuration.valid_roles.each do |role|
-      Role.create(:name => role.to_s)
+      r = Role.new
+      r.name = role.to_s
+      r.save
     end
   end
 end


### PR DESCRIPTION
The recent mass-assignment protection update to Rails causes the migration that creates the roles table to fail. The migration attempts to mass-assign the name attribute which now fails because that attribute is not explicitly white-listed in the model.

This commit directly sets the name attribute during the migration rather than attempting a mass assignment.
